### PR TITLE
remove single item page delete button

### DIFF
--- a/app/templates/views/single_food_item.html
+++ b/app/templates/views/single_food_item.html
@@ -3,7 +3,6 @@
     <li data-ng-repeat="item in singleFood">
       {{item.itemName}}
       <button data-ng-if="!item.editing" data-ng-disabled="!item._id" data-ng-click="editItem(item)">Edit</button>
-      <button data-ng-if="!item.editing" data-ng-click="removeItem(item)">Delete</button>
       <div data-single-food-item-edit-directive
             data-save="saveItem(item)"
             data-button-text="'Save'"


### PR DESCRIPTION
Decided to not include a delete button in the single item page view. The logic behind this is that if an item is meant to be deleted, then this item should be deleted in the 'list view' for selection rather than the item itself (from the inventory/ homepage).